### PR TITLE
feat: Deepcopy, attribute fix

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -27,7 +27,7 @@ class BaseModel:
         Includes the key/value pair __class__ representing
         the class name of the object.
         """
-        rdict = self.__dict__.copy()
+        rdict = copy.deepcopy(self.__dict__)
         rdict["created_at"] = self.created_at.isoformat()
         rdict["updated_at"] = self.updated_at.isoformat()
         rdict["__class__"] = self.__class__.__name__


### PR DESCRIPTION
I made changes to the copy module, self.__dict__.copy() since it creates a shallow copy of the object's attributes.