### PR TITLE
feat: add ability to handle double quotes in console arguments

### DIFF
--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -40,10 +40,11 @@ class FileStorage:
 
         try:
             with open(FileStorage.__file_path) as f:
-                objdict = json.load(f)
-                for o in objdict.values():
-                    cls_name = o["__class__"]
-                    del o["__class__"]
-                    self.new(eval(cls_name)(**o))
+                if f.read() != '':
+                    objdict = json.load(f)
+                    for o in objdict.values():
+                        cls_name = o["__class__"]
+                        del o["__class__"]
+                        self.new(eval(cls_name)(**o))
         except FileNotFoundError:
             return


### PR DESCRIPTION
This pull request creates a new feature in the console and fixes one issue:

### New console feature: The console can now handle arguments with double quotes. For example in the case below:

`update User some-id name "George Ikigu"`

`"George Ikigu"` will be treated as a single argument and the name will be updated accordingly, e.g `{'name': 'George Ikigu'}`

### Fix: If the file.json file exists but is empty, running the console doesn't throw a JSONDecodeError

I added a check in the `reload` method on `file_storage.py` to read the file and check whether we get back an empty string. All the operations of recreating the objects are only ran if we get back some text.

